### PR TITLE
Bump `uid2` for license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "pkginfo": "0.2.x",
     "passport-oauth": "1.0.0",
-    "uid2": "0.0.3"
+    "uid2": "0.0.4"
   },
   "devDependencies": {
     "vows": "0.6.x"


### PR DESCRIPTION
`uid2@0.0.4` now includes an explicit `license` property in it's `package.json` file, which makes automated license tracking easier.

The diff from `0.0.3` is minimal - the only code changes appear to be a no-op [1]
[1] https://github.com/coreh/uid2/compare/0.0.3...0.0.4